### PR TITLE
Crash fixes

### DIFF
--- a/AudioPlayer.cs
+++ b/AudioPlayer.cs
@@ -189,7 +189,7 @@ namespace KlangRageAudioLibrary
 
         public void Dispose()
         {
-            SoundInstances?.ForEach(x => { x.Stop(); x.Dispose(); });
+            SoundInstances?.ForEach(x => x.Stop());
             SoundInstances?.Clear();
             Disposed = true;
         }

--- a/Utility/ExternalThread.cs
+++ b/Utility/ExternalThread.cs
@@ -34,7 +34,18 @@ namespace KlangRageAudioLibrary.Utility
         {
             GetWindowThreadProcessId(GetForegroundWindow(), out int activeProcessId);
 
-            return System.Diagnostics.Process.GetProcessById(activeProcessId);
+            System.Diagnostics.Process temp;
+
+            try
+            {
+                temp = System.Diagnostics.Process.GetProcessById(activeProcessId);
+            }
+            catch
+            {
+                temp = null;
+            }
+
+            return temp;
         }
 
         private void Tick()
@@ -62,7 +73,7 @@ namespace KlangRageAudioLibrary.Utility
                     }
                 }
 
-                AudioEngine.MuteAll(GetActiveAppProcess().ProcessName != "GTA5");
+                AudioEngine.MuteAll(GetActiveAppProcess()?.ProcessName != "GTA5");
             }
         }
     }


### PR DESCRIPTION
Fixed thread deadlock race condition between the finalizer of KlangRageAudioLibrary and the finalizer of irrKlang.NET4 by not explicitly calling the finalizer of irrKlang in KRAL and leaving it up irrKlang itself and the GC. Also fixed a random script crash that could occur if the player alt-tabs away from GTAV while unpaused then exits a program that had previously been the active window.